### PR TITLE
Rename WebExtension provider to 'webext'

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 This module tries to connect to IPFS via multiple providers, in order:
 
-- `ipfs-companion` the IPFS instance from [IPFS Companion](https://github.com/ipfs-shipyard/ipfs-companion) directly.
-- `window.ipfs` in the current page via [IPFS Companion](https://github.com/ipfs-shipyard/ipfs-companion).
-- `js-ipfs-http-client` with either a user provided `apiAddress`, the current origin, or the default `/ip4/127.0.0.1/tcp/5001` address.
-- `js-ipfs` **disabled by default**. See [Enable js-ipfs](#enable-js-ipfs) for more info.
+- `webext` is looking for instance in [background page of WebExtension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/extension/getBackgroundPage) (not used on regular web)
+- [`window.ipfs`](https://github.com/ipfs-shipyard/ipfs-companion/blob/master/docs/window.ipfs.md) proxy in the current page (provided by [IPFS Companion](https://github.com/ipfs-shipyard/ipfs-companion) browser extension)
+- [`js-ipfs-http-client`](https://github.com/ipfs/js-ipfs-http-client) with either a user provided `apiAddress`, the current origin, or the default `/ip4/127.0.0.1/tcp/5001` address
+- [`js-ipfs`](https://github.com/ipfs/js-ipfs) is spawning a full IPFS node (**Disabled by default:** see [Enable js-ipfs](#enable-js-ipfs) for more info)
 
 
 This is a port of the [ipfs-redux-bundle](https://github.com/ipfs-shipyard/ipfs-redux-bundle).
@@ -30,7 +30,7 @@ import getIpfs from 'ipfs-provider'
 
 const { ipfs, provider } = await getIpfs({
   // These are the defaults:
-  tryCompanion: true, // set false to bypass ipfs-companion verification
+  tryWebExt: true,    // set false to bypass WebExtension verification
   tryWindow: true,    // set false to bypass window.ipfs verification
   tryApi: true,       // set false to bypass js-ipfs-http-client verification
   apiAddress: null    // set this to use an api in that address if tryApi is true
@@ -41,7 +41,7 @@ const { ipfs, provider } = await getIpfs({
 ```
 
 - `ipfs` is the running IPFS instance.
-- `provider` is a string representing the chosen provider, either: `IPFS_COMPANION`, `WINDOW_IPFS`, `IPFS_HTTP_API` or `JS_IPFS`.
+- `provider` is a string representing the chosen provider, either: `WEBEXT`, `WINDOW_IPFS`, `IPFS_HTTP_API` or `JS_IPFS`.
 
 ### Enable js-ipfs
 

--- a/src/constants/providers.js
+++ b/src/constants/providers.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  companion: 'IPFS_COMPANION',
+  webext: 'WEBEXT',
   window: 'WINDOW_IPFS',
   api: 'IPFS_HTTP_API',
   jsipfs: 'JS_IPFS'

--- a/src/index.js
+++ b/src/index.js
@@ -4,14 +4,14 @@ const root = require('window-or-global')
 const multiaddr = require('multiaddr')
 const IpfsApi = require('ipfs-http-client')
 
-const tryCompanion = require('./providers/ipfs-companion')
+const tryWebExt = require('./providers/webext')
 const tryWindow = require('./providers/window-ipfs')
 const tryApi = require('./providers/ipfs-http-api')
 const tryJsIpfs = require('./providers/js-ipfs')
 
 async function getIpfs (opts) {
   const defaultOpts = {
-    tryCompanion: true,
+    tryWebExt: true,
     tryWindow: true,
     tryApi: true,
     tryJsIpfs: false,
@@ -32,8 +32,8 @@ async function getIpfs (opts) {
 
   const { ipfsConnectionTest } = opts
 
-  if (opts.tryCompanion) {
-    const res = await tryCompanion({ root, ipfsConnectionTest })
+  if (opts.tryWebExt) {
+    const res = await tryWebExt({ root, ipfsConnectionTest })
     if (res) return res
   }
 

--- a/src/providers/webext.js
+++ b/src/providers/webext.js
@@ -2,8 +2,8 @@
 
 const PROVIDERS = require('../constants/providers')
 
-async function tryCompanion ({ root, ipfsConnectionTest }) {
-  // Opportunistic optimizations when running from ipfs-companion (+ ipfs-desktop in future)
+async function tryWebExt ({ root, ipfsConnectionTest }) {
+  // Opportunistic optimizations when running inside of web extension (eg. ipfs-companion)
   if (typeof root.chrome === 'object' && root.chrome.extension && root.chrome.extension.getBackgroundPage) {
     // Note: under some vendors getBackgroundPage() will return null if window is in incognito mode
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1329304
@@ -14,13 +14,17 @@ async function tryCompanion ({ root, ipfsConnectionTest }) {
       // no ipfs companion for you
       return null
     }
-    // If extension is ipfs-companion exposing IPFS API, use it directly for best performance
+    // If extension is ipfs-companion and it is exposing IPFS API,
+    // use it directly for the best performance
     if (webExt && webExt.ipfsCompanion && webExt.ipfsCompanion.ipfs) {
       const ipfs = webExt.ipfsCompanion.ipfs
       await ipfsConnectionTest(ipfs)
-      return { ipfs, provider: PROVIDERS.companion }
+      return { ipfs, provider: PROVIDERS.webext }
     }
+    /*  Other endpoints can be added here in the future.
+        For example, Companion could provide API for other browser extensions:
+        https://github.com/ipfs-shipyard/ipfs-companion/issues/307 */
   }
 }
 
-module.exports = tryCompanion
+module.exports = tryWebExt

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,14 +1,14 @@
 'use strict'
 /* global jest, describe, it, expect */
 
-const tryCompanion = require('../src/providers/ipfs-companion.js')
+const tryWebExt = require('../src/providers/webext.js')
 const tryWindow = require('../src/providers/window-ipfs.js')
 const tryApi = require('../src/providers/ipfs-http-api.js')
 const tryJsIpfs = require('../src/providers/js-ipfs.js')
 const PROVIDERS = require('../src/constants/providers.js')
 const getIpfs = require('../src/index.js')
 
-jest.mock('../src/providers/ipfs-companion.js')
+jest.mock('../src/providers/webext.js')
 jest.mock('../src/providers/window-ipfs.js')
 jest.mock('../src/providers/ipfs-http-api.js')
 jest.mock('../src/providers/js-ipfs.js')
@@ -16,7 +16,7 @@ jest.mock('../src/providers/js-ipfs.js')
 describe('getIpfs via availabe providers', () => {
   it('should try nothing and fail if all providers are disabled', async () => {
     const res = await getIpfs({
-      tryCompanion: false,
+      tryWebExt: false,
       tryWindow: false,
       tryApi: false,
       tryJsIpfs: false
@@ -24,18 +24,18 @@ describe('getIpfs via availabe providers', () => {
     expect(res).toBeFalsy()
   })
 
-  it('should try ipfs-companion first', async () => {
-    const mockResult = { ipfs: {}, provider: PROVIDERS.companion }
-    tryCompanion.mockResolvedValue(mockResult)
+  it('should try webext first', async () => {
+    const mockResult = { ipfs: {}, provider: PROVIDERS.webext }
+    tryWebExt.mockResolvedValue(mockResult)
     tryWindow.mockResolvedValue({ ipfs: {}, provider: 'nope' })
     const { ipfs, provider } = await getIpfs()
     expect(ipfs).toBeTruthy()
     expect(provider).toBe(mockResult.provider)
   })
 
-  it('should try window.ipfs after companion', async () => {
+  it('should try window.ipfs after webext', async () => {
     const mockResult = { ipfs: {}, provider: PROVIDERS.window }
-    tryCompanion.mockResolvedValue(null)
+    tryWebExt.mockResolvedValue(null)
     tryWindow.mockResolvedValue(mockResult)
     const { ipfs, provider } = await getIpfs()
     expect(ipfs).toBeTruthy()
@@ -44,7 +44,7 @@ describe('getIpfs via availabe providers', () => {
 
   it('should try ipfs-http-api after window.ipfs', async () => {
     const mockResult = { ipfs: {}, provider: PROVIDERS.api }
-    tryCompanion.mockResolvedValue(null)
+    tryWebExt.mockResolvedValue(null)
     tryWindow.mockResolvedValue(null)
     tryApi.mockResolvedValue(mockResult)
     const { ipfs, provider } = await getIpfs()
@@ -54,7 +54,7 @@ describe('getIpfs via availabe providers', () => {
 
   it('should try js-ipfs if enabled', async () => {
     const mockResult = { ipfs: {}, provider: PROVIDERS.jsipfs }
-    tryCompanion.mockResolvedValue(null)
+    tryWebExt.mockResolvedValue(null)
     tryWindow.mockResolvedValue(null)
     tryApi.mockResolvedValue(null)
     tryJsIpfs.mockResolvedValue(mockResult)

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -3,14 +3,14 @@
 
 const IpfsApi = require('ipfs-http-client')
 
-const tryCompanion = require('../src/providers/ipfs-companion.js')
+const tryWebExt = require('../src/providers/webext.js')
 const tryWindow = require('../src/providers/window-ipfs.js')
 const tryApi = require('../src/providers/ipfs-http-api.js')
 const tryJsIpfs = require('../src/providers/js-ipfs.js')
 const PROVIDERS = require('../src/constants/providers.js')
 
-describe('provider: ipfs-companion', () => {
-  it('should connect to ipfs-companion', async () => {
+describe('provider: webext', () => {
+  it('should connect to webext', async () => {
     // chrome.extension.getBackgroundPage().ipfsCompanion.ipfs will be present
     // only if page was loaded from a path that belongs to our browser extension
     const mockIpfs = {}
@@ -31,9 +31,9 @@ describe('provider: ipfs-companion', () => {
       expect(ipfs).toEqual(mockIpfs)
       Promise.resolve()
     }
-    const { ipfs, provider } = await tryCompanion({ root, ipfsConnectionTest })
+    const { ipfs, provider } = await tryWebExt({ root, ipfsConnectionTest })
     expect(ipfs).toEqual(mockIpfs)
-    expect(provider).toEqual(PROVIDERS.companion)
+    expect(provider).toEqual(PROVIDERS.webext)
   })
 })
 


### PR DESCRIPTION
### Context

Use of "ipfs-companion" as a provider name here was really confusing.
It suggested API exposed by Companion is used and most of the people think it means `window.ipfs`.
Then the real `window.ipfs` was listed below as a separate provider, which caused decision paralysis. 

### Changes

This PR renames `ipfs-companion` provider to "webext". "companion" is no longer used in provider name present in README. Companion is only mentioned in the description of `window.ipfs` provider, which is what we want.

**Note:** this provider is not used at the moment. We used  it when ipfs-webui  was bundled inside of ipfs-companion, but we switched to loading webui from IPFS, so this PR is safe to merge (it won't impact anyone). We may use it in the future if we decide to bundle more complex apps with ipfs-companion, or expose IPFS API to other extensions (https://github.com/ipfs-shipyard/ipfs-companion/issues/307)

