### PR TITLE
feat: lazy load js-ipfs-http-client and async iterator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Please keep in mind that all of these have defaults and you **do not** need to s
 Tries to connect to HTTP API via [`js-ipfs-http-client`](https://github.com/ipfs/js-ipfs-http-client).
 This provider will establish connection with `apiAddress`, the current origin, or the default local API address (`/ip4/127.0.0.1/tcp/5001`).
 
-The client library is initialized using constructor returned by `getConstructor` function or the one exposed at `window.IpfsHttpClient`.
+The client library is initialized using a constructor returned by `loadHttpClientModule` async function or one exposed at `window.IpfsHttpClient`.
 Supports lazy-loading and small bundle sizes.
 
 Value provided in `apiAddress` can be:
@@ -101,7 +101,7 @@ Value provided in `apiAddress` can be:
 const { ipfs, provider } = await getIpfs({
   providers: [
     httpClient({
-      getConstructor: () => import('ipfs-http-client'),
+      loadHttpClientModule: () => require('ipfs-http-client'),
       apiAddress: 'https://api.example.com:8080/'
     })
   ]
@@ -120,15 +120,17 @@ in the context of the current page using customizable constructor:
 const { ipfs, provider } = await getIpfs({
   providers: [
     jsIpfs({
-      getConstructor: () => import('ipfs'),
+      loadJsIpfsModule: () => require('ipfs'),
       options: { /* advanced config */ }
     })
   ]
 })
 ```
 
-- `getConstructor` should be a function that returns a promise that resolves with a `JsIpfs` constructor.  
+- `loadJsIpfsModule` should be a function that returns a promise that resolves with a [js-ipfs](https://github.com/ipfs/js-ipfs) constructor.
+   <!-- TODO confirm below is true, if it is, add example to examples/ and link to it
    This works well with [dynamic `import()`](https://developers.google.com/web/updates/2017/11/dynamic-import), so you can lazily load js-ipfs when it is needed.
+   -->
 - `options` should be an object which specifies [advanced configurations](https://github.com/ipfs/js-ipfs#ipfs-constructor) to the node.
 
 ### `windowIpfs`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://flat.badgen.net/travis/ipfs-shipyard/ipfs-provider)](https://travis-ci.com/ipfs-shipyard/ipfs-provider)
 [![Dependency Status](https://david-dm.org/ipfs-shipyard/ipfs-provider.svg?style=flat-square)](https://david-dm.org/ipfs-shipyard/ipfs-provider)
 
-> This module tries to connect to IPFS via multiple [providers](#providers).  
+> Returns IPFS API by trying multiple [providers](#providers) in a custom fallback order.  
 > It is a general-purpose replacement for [ipfs-redux-bundle](https://github.com/ipfs-shipyard/ipfs-redux-bundle).
 
 - [Install](#install)
@@ -85,21 +85,24 @@ Please keep in mind that all of these have defaults and you **do not** need to s
 
 ### `httpClient`
 
-Tries to connect to HTTP API via [`js-ipfs-http-client`](https://github.com/ipfs/js-ipfs-http-client) with either a user provided `apiAddress`, the current origin, or `defaultApiAddress`.
+Tries to connect to HTTP API via [`js-ipfs-http-client`](https://github.com/ipfs/js-ipfs-http-client).
+This provider will establish connection with `apiAddress`, the current origin, or the default local API address (`/ip4/127.0.0.1/tcp/5001`).
 
-Value provided in `apiAddress`  can be:
+The client library is initialized using constructor returned by `getConstructor` function or the one exposed at `window.IpfsHttpClient`.
+Supports lazy-loading and small bundle sizes.
+
+Value provided in `apiAddress` can be:
 - a multiaddr (string like `/ip4/127.0.0.1/tcp/5001` or an [object](https://github.com/multiformats/js-multiaddr/))
-- a String with an URL (`https://example.com:8080/`)
+- a String with an URL (`https://api.example.com:8080/`)
 - a configuration object supported by [`js-ipfs-http-client`](https://github.com/ipfs/js-ipfs-http-client#importing-the-module-and-usage)
-
+  (`{ host: '1.1.1.1', port: '80', apiPath: '/ipfs/api/v0' }`)
 
 ```js
 const { ipfs, provider } = await getIpfs({
   providers: [
     httpClient({
-      // defaults
-      defaultApiAddress: '/ip4/127.0.0.1/tcp/5001',
-      apiAddress: null
+      getConstructor: () => import('ipfs-http-client'),
+      apiAddress: 'https://api.example.com:8080/'
     })
   ]
 })
@@ -107,7 +110,6 @@ const { ipfs, provider } = await getIpfs({
 
 To try multiple endpoints, simply use this provider multiple times.  
 See [`examples/browser-browserify/src/index.js`](./examples/browser-browserify/src/index.js) for real world example.
-
 
 ### `jsIpfs`
 
@@ -118,7 +120,6 @@ in the context of the current page using customizable constructor:
 const { ipfs, provider } = await getIpfs({
   providers: [
     jsIpfs({
-      // defaults
       getConstructor: () => import('ipfs'),
       options: { /* advanced config */ }
     })

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,5 +14,5 @@ Let us know if you find any issue or if you want to contribute and add an exampl
 
 ## See also
 
-- [`js-ipfs-http-client` examples](https://github.com/ipfs/js-ipfs-http-client/tree/master/examples)
+- [`js-ipfs-http-client` examples](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client/examples)
 - [`js-ipfs` examples and tutorials](https://github.com/ipfs/js-ipfs/tree/master/examples)

--- a/examples/browser-browserify/README.md
+++ b/examples/browser-browserify/README.md
@@ -27,4 +27,4 @@ Let's unpack what happened in the above example:
 2. 🔴 test request to local API (`/ip4/127.0.0.1/tcp/5001`) was blocked due to [CORS protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
 3. 🔴 `/api/v0/` on the same Origin as the page did not exist
 3. 🔴 explicitly defined remote API was offline (`http://dev.local:8080`)
-4. 💚 final fallback of spawning embedded [js-ipfs](https://github.com/ipfs/js-ipfs) was executed successfully 🚀✨
+4. 💚 final fallback worked: spawning embedded [js-ipfs](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs) was executed successfully 🚀✨

--- a/examples/browser-browserify/package.json
+++ b/examples/browser-browserify/package.json
@@ -19,7 +19,8 @@
     "ipfs-provider": "file:../../"
   },
   "dependencies": {
-    "ipfs": "0.40.0"
+    "ipfs": "0.40.0",
+    "ipfs-http-client": "40.1.0"
   },
   "browser": {
     "ipfs": "ipfs/dist"

--- a/examples/browser-browserify/package.json
+++ b/examples/browser-browserify/package.json
@@ -12,15 +12,16 @@
   "keywords": [],
   "license": "MIT",
   "devDependencies": {
-    "browserify": "^16.2.3",
+    "browserify": "^16.5.1",
     "concat-stream": "^2.0.0",
     "execa": "^4.0.0",
-    "http-server": "~0.12.0",
+    "http-server": "~0.12.1",
     "ipfs-provider": "file:../../"
   },
   "dependencies": {
-    "ipfs": "0.40.0",
-    "ipfs-http-client": "40.1.0"
+    "buffer": "5.6.0",
+    "ipfs": "0.43.0",
+    "ipfs-http-client": "44.0.0"
   },
   "browser": {
     "ipfs": "ipfs/dist"

--- a/examples/browser-browserify/public/index.html
+++ b/examples/browser-browserify/public/index.html
@@ -15,11 +15,12 @@
   </head>
   <body>
     <h2>Add data to IPFS from the browser via API found by ipfs-provider</h2>
+    <p>(open the Console to see what is happening)</p>
     <textarea id="source" placeholder="Enter some text here"></textarea>
     <button id="store">Add text</button>
     <div id="output" style="display: none">
-      <p>CID and text read back from IPFS:</p>
-      <div class="content" id="hash">[ipfs hash]</div>
+      <p>CID and the text read back from IPFS:</p>
+      <div class="content" id="cid">[ipfs cid]</div>
       <div class="content" id="content">[ipfs content]</div>
     </div>
   </body>

--- a/examples/browser-browserify/src/index.js
+++ b/examples/browser-browserify/src/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const { getIpfs, providers } = require('ipfs-provider')
 const { httpClient, jsIpfs, windowIpfs } = providers
 
@@ -25,9 +26,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         apiAddress: 'http://dev.local:8080'
       }),
       jsIpfs({
-        // js-ipfs package is used here, so it is ok to inline it
+        // js-ipfs package is used only once, here
         loadJsIpfsModule: () => require('ipfs'), // note require instead of
-        options: { } // pass config: https://github.com/ipfs/js-ipfs#ipfs-constructor
+        options: { } // pass config: https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs/docs/MODULE.md#ipfscreateoptions
       })
     ]
   })
@@ -39,18 +40,23 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   async function store () {
     const toStore = document.getElementById('source').value
-    const result = await ipfs.add(toStore)
-    for (const file of result) {
-      if (file && file.hash) {
-        console.log('successfully stored', file.hash)
-        await display(file.hash)
+    for await (const file of ipfs.add(toStore)) {
+      if (file && file.cid) {
+        console.log('successfully stored', file)
+        await display(file.cid.toString())
+      } else {
+        console.error('unable to add', file)
       }
     }
   }
 
-  async function display (hash) {
-    const data = await ipfs.cat(hash)
-    document.getElementById('hash').innerText = hash
+  async function display (cid) {
+    const chunks = []
+    for await (const chunk of ipfs.cat(cid)) {
+      chunks.push(chunk)
+    }
+    const data = Buffer.concat(chunks).toString()
+    document.getElementById('cid').innerText = cid
     document.getElementById('content').innerText = data
     document.getElementById('output').setAttribute('style', 'display: block')
   }

--- a/examples/browser-browserify/src/index.js
+++ b/examples/browser-browserify/src/index.js
@@ -4,7 +4,10 @@ const { getIpfs, providers } = require('ipfs-provider')
 const { httpClient, jsIpfs, windowIpfs } = providers
 
 document.addEventListener('DOMContentLoaded', async () => {
-  const { ipfs, provider } = await getIpfs({
+  const { ipfs, provider, apiAddress } = await getIpfs({
+    // HTTP client library can be defined globally to keep code minimal
+    // when httpClient provider is used multiple times
+    loadHttpClientModule: () => require('ipfs-http-client'),
     // try window.ipfs (if present),
     // then http apis (if up),
     // and finally fallback to spawning embedded js-ipfs
@@ -22,13 +25,17 @@ document.addEventListener('DOMContentLoaded', async () => {
         apiAddress: 'http://dev.local:8080'
       }),
       jsIpfs({
-        getConstructor: () => require('ipfs'), // note: 'require' can be used instead of 'import'
+        // js-ipfs package is used here, so it is ok to inline it
+        loadJsIpfsModule: () => require('ipfs'), // note require instead of
         options: { } // pass config: https://github.com/ipfs/js-ipfs#ipfs-constructor
       })
     ]
   })
 
   console.log('IPFS API is provided by: ' + provider)
+  if (provider === 'httpClient') {
+    console.log('HTTP API address: ' + apiAddress)
+  }
 
   async function store () {
     const toStore = document.getElementById('source').value

--- a/package-lock.json
+++ b/package-lock.json
@@ -719,6 +719,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -894,12 +895,14 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -987,7 +990,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -1048,6 +1052,7 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
       "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -1055,7 +1060,8 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -1069,12 +1075,14 @@
     "bignumber.js": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+      "dev": true
     },
     "bl": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
       "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "dev": true,
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -1084,12 +1092,14 @@
     "blakejs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
+      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U=",
+      "dev": true
     },
     "borc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
       "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+      "dev": true,
       "requires": {
         "bignumber.js": "^9.0.0",
         "buffer": "^5.5.0",
@@ -1104,6 +1114,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1145,6 +1156,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "dev": true,
       "requires": {
         "base-x": "^3.0.2"
       }
@@ -1162,6 +1174,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
       "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -1243,6 +1256,7 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.0.tgz",
       "integrity": "sha512-HdKURxtSOnww3H28CJU2TauIklEBsOn+ouGl2EOnSfVCVkH6+sWTj7to2D/BmuWvwzEy2+ZIKdcIwsXHJBQVew==",
+      "dev": true,
       "requires": {
         "buffer": "^5.5.0",
         "class-is": "^1.1.0",
@@ -1254,7 +1268,8 @@
     "class-is": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
-      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
+      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==",
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -1346,6 +1361,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1353,7 +1369,8 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -1364,7 +1381,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "contains-path": {
       "version": "0.1.0",
@@ -1478,6 +1496,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -1587,12 +1606,14 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "delimit-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
+      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs=",
+      "dev": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -1652,7 +1673,8 @@
     "err-code": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-      "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+      "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw==",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -2230,7 +2252,8 @@
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true
     },
     "exec-sh": {
       "version": "0.3.4",
@@ -2441,7 +2464,8 @@
     "fast-fifo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.0.0.tgz",
-      "integrity": "sha512-4VEXmjxLj7sbs8J//cn2qhRap50dGzF5n8fjay8mau+Jn4hxSeR3xPFwxMaQq/pDaq7+KQk0PAbC2+nWDkJrmQ=="
+      "integrity": "sha512-4VEXmjxLj7sbs8J//cn2qhRap50dGzF5n8fjay8mau+Jn4hxSeR3xPFwxMaQq/pDaq7+KQk0PAbC2+nWDkJrmQ==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -2571,6 +2595,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
       "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+      "dev": true,
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -2618,7 +2643,8 @@
     "get-iterator": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
-      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg==",
+      "dev": true
     },
     "get-stdin": {
       "version": "7.0.0",
@@ -2682,7 +2708,8 @@
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "dev": true
     },
     "growly": {
       "version": "1.3.0",
@@ -2783,7 +2810,8 @@
     "hi-base32": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.0.tgz",
-      "integrity": "sha512-DDRmxSyoYuvjUb9EnXdoiMChBZ7ZcUVJsK5Frd3kqMhuBxvmZdnBeynAVfj7/ECbn++CekcoprvC/rprHPAtow=="
+      "integrity": "sha512-DDRmxSyoYuvjUb9EnXdoiMChBZ7ZcUVJsK5Frd3kqMhuBxvmZdnBeynAVfj7/ECbn++CekcoprvC/rprHPAtow==",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.8.8",
@@ -2835,7 +2863,8 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
     },
     "ignore": {
       "version": "4.0.6",
@@ -2890,7 +2919,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "inquirer": {
       "version": "7.1.0",
@@ -2916,7 +2946,8 @@
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -2928,6 +2959,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.8.1.tgz",
       "integrity": "sha512-0FaCpmij+jZBoUYhjoB5ptjdl9QzvrdRIoBmUU5JiBnK2GA+4YM/ifklaB8ePRhA/rRzhd+KYBjvMFMAL4NrVQ==",
+      "dev": true,
       "requires": {
         "cids": "~0.7.0",
         "class-is": "^1.1.0"
@@ -2937,6 +2969,7 @@
           "version": "0.7.5",
           "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
           "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+          "dev": true,
           "requires": {
             "buffer": "^5.5.0",
             "class-is": "^1.1.0",
@@ -2949,6 +2982,7 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
           "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+          "dev": true,
           "requires": {
             "base-x": "^3.0.8",
             "buffer": "^5.5.0"
@@ -2960,6 +2994,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.2.0.tgz",
       "integrity": "sha512-rFelMi8m4Arqj/qHV+PXCVK7kqbpuqP8wqMSJ0rObwIqV+UvNsDZ6hOSamOkgKv77qDXThbe6nrc9JsbuH8D6w==",
+      "dev": true,
       "requires": {
         "buffer": "^5.4.2",
         "err-code": "^2.0.0",
@@ -2970,6 +3005,7 @@
       "version": "44.0.0",
       "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-44.0.0.tgz",
       "integrity": "sha512-vFGM8eKipeJ7MEgare9zXVJqQ37pLUdNP4fpIvfzDfEgpK6OmJR3UaoZ1RtKwKGnHi/ADU3Dc5rGWd/YwiaR9g==",
+      "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "bignumber.js": "^9.0.0",
@@ -3004,6 +3040,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
           "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -3016,6 +3053,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.2.0.tgz",
       "integrity": "sha512-V4pq/BYpWupB+QdVEBnNl/B7uMx3glLVCGAQRGI66DQJTa78vdcEyD8XeRB4wUUFMbxUo1s0J0CH/pJsYNgF9A==",
+      "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "buffer": "^5.4.2",
@@ -3034,6 +3072,7 @@
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.15.2.tgz",
       "integrity": "sha512-Ioni4s959P/CtkWQOt1TXrj4zqc3MoPxvHrEmybCn5JFdG3dpBNJR1oBVvP6uUrmF5bBtUGKNbX1pSI5SEOaHg==",
+      "dev": true,
       "requires": {
         "borc": "^2.1.2",
         "buffer": "^5.5.0",
@@ -3047,6 +3086,7 @@
       "version": "0.18.3",
       "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.3.tgz",
       "integrity": "sha512-lE/7m5DesBqJCCIom/ohJmQViaMOKWBleB0u3yjWGJoWxqhzoQAFL0tLRNFYardUnVvqxgP+tpvoAJMGaFNNOA==",
+      "dev": true,
       "requires": {
         "cids": "~0.7.3",
         "class-is": "^1.1.0",
@@ -3060,6 +3100,7 @@
           "version": "0.7.5",
           "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
           "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+          "dev": true,
           "requires": {
             "buffer": "^5.5.0",
             "class-is": "^1.1.0",
@@ -3072,6 +3113,7 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
           "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+          "dev": true,
           "requires": {
             "base-x": "^3.0.8",
             "buffer": "^5.5.0"
@@ -3083,6 +3125,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-4.0.1.tgz",
       "integrity": "sha512-WjIdtZ06jJEar8zh+BHB84tE6ZdbS/XNa7+XCArOYfmeJ/c01T9VQpeMwdJQYn5c3s5UvvCu7y4VIi3vk2g1bA==",
+      "dev": true,
       "requires": {
         "cids": "~0.7.0",
         "multicodec": "^1.0.0",
@@ -3093,6 +3136,7 @@
           "version": "0.7.5",
           "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
           "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+          "dev": true,
           "requires": {
             "buffer": "^5.5.0",
             "class-is": "^1.1.0",
@@ -3105,6 +3149,7 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
           "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+          "dev": true,
           "requires": {
             "base-x": "^3.0.8",
             "buffer": "^5.5.0"
@@ -3162,7 +3207,8 @@
     "is-circular": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
-      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
+      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA==",
+      "dev": true
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -3212,7 +3258,8 @@
     "is-electron": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
-      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
+      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q==",
+      "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -3337,7 +3384,8 @@
     "iso-constants": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/iso-constants/-/iso-constants-0.1.2.tgz",
-      "integrity": "sha512-OTCM5ZCQsHBCI4Wdu4tSxvDIkmDHd5EwJDps5mKqnQnWJSKlnwMs3EDZ4n3Fh1tmkWkDlyd2vCDbEYuPbyrUNQ=="
+      "integrity": "sha512-OTCM5ZCQsHBCI4Wdu4tSxvDIkmDHd5EwJDps5mKqnQnWJSKlnwMs3EDZ4n3Fh1tmkWkDlyd2vCDbEYuPbyrUNQ==",
+      "dev": true
     },
     "iso-url": {
       "version": "0.4.7",
@@ -3413,6 +3461,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/it-concat/-/it-concat-1.0.0.tgz",
       "integrity": "sha512-mLhiCB3tW4NTYTg7bMlyYX2c782KsAacthHMR3y5kjJn9JhNFb02NcH70KZuNrSXFSTq8k6m8MiYaQWRjrDxAA==",
+      "dev": true,
       "requires": {
         "bl": "^4.0.0"
       }
@@ -3421,6 +3470,7 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.7.tgz",
       "integrity": "sha512-XfbziJs4fi0MfdEGTLkZXeqo2EorF2baFXxFn1E2dGbgYMhFTZlZ2Yn/mx5CkpuLWVJvO1DwtTOVW2mzRyVK8w==",
+      "dev": true,
       "requires": {
         "fs-extra": "^8.1.0",
         "minimatch": "^3.0.4"
@@ -3430,6 +3480,7 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -3440,6 +3491,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
           }
@@ -3447,7 +3499,8 @@
         "universalify": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
         }
       }
     },
@@ -3455,6 +3508,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-2.1.0.tgz",
       "integrity": "sha512-hSysqWTO9Tlwc5EGjVf8JYZzw0D2FsxD/g+eNNWrez9zODxWt6QlN6JAMmycK72Mv4jHEKEXoyzUN4FYGmJaZw==",
+      "dev": true,
       "requires": {
         "bl": "^4.0.0"
       }
@@ -3463,6 +3517,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/it-tar/-/it-tar-1.2.2.tgz",
       "integrity": "sha512-M8V4a9I+x/vwXTjqvixcEZbQZHjwDIb8iUQ+D4M2QbhAdNs3WKVSl+45u5/F2XFx6jYMFOGzMVlKNK/uONgNIA==",
+      "dev": true,
       "requires": {
         "bl": "^4.0.0",
         "buffer": "^5.4.3",
@@ -3476,6 +3531,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/it-to-buffer/-/it-to-buffer-1.0.1.tgz",
       "integrity": "sha512-7ncNESNc5v2baA5CTTd89L4Nzd/44Yts2GZYep6ENLfDcXQpNAM0xlWBSQUvcsqf50Vov5cANI4NstX6BdH6Pg==",
+      "dev": true,
       "requires": {
         "buffer": "^5.5.0"
       }
@@ -3484,6 +3540,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-0.1.1.tgz",
       "integrity": "sha512-QQx/58JBvT189imr6fD234F8aVf8EdyQHJR0MxXAOShEWK1NWyahPYIQt/tQG7PId0ZG/6/3tUiVCfw2cq+e1w==",
+      "dev": true,
       "requires": {
         "buffer": "^5.2.1",
         "fast-fifo": "^1.0.0",
@@ -3985,7 +4042,8 @@
     "js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -4083,6 +4141,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
       "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+      "dev": true,
       "requires": {
         "delimit-stream": "0.1.0"
       }
@@ -4100,6 +4159,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
       "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^1.0.0"
@@ -4289,12 +4349,14 @@
     "mime-db": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.26",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
       "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "dev": true,
       "requires": {
         "mime-db": "1.43.0"
       }
@@ -4309,6 +4371,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -4352,12 +4415,14 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "multiaddr": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.2.1.tgz",
       "integrity": "sha512-iJ372ZXoyw1xmRh3Cawej5l17TTs72jGHDjUHCDl16s3UFkkPQkWj90BDF8hw8xnBIG/JB3RAyHhkWKiuNfM5g==",
+      "dev": true,
       "requires": {
         "bs58": "^4.0.1",
         "cids": "~0.7.1",
@@ -4372,6 +4437,7 @@
           "version": "0.7.5",
           "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
           "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+          "dev": true,
           "requires": {
             "buffer": "^5.5.0",
             "class-is": "^1.1.0",
@@ -4383,12 +4449,14 @@
         "ip-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
-          "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
+          "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA==",
+          "dev": true
         },
         "is-ip": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
           "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+          "dev": true,
           "requires": {
             "ip-regex": "^4.0.0"
           }
@@ -4397,6 +4465,7 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
           "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+          "dev": true,
           "requires": {
             "base-x": "^3.0.8",
             "buffer": "^5.5.0"
@@ -4408,6 +4477,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-5.1.0.tgz",
       "integrity": "sha512-rIlMLkw3yk3RJmf2hxYYzeqPXz4Vx7C4M/hg7BVWhmksDW0rDVNMEyoVb0H1A+sh3deHOh5EAFK87XcW+mFimA==",
+      "dev": true,
       "requires": {
         "multiaddr": "^7.2.1"
       }
@@ -4416,6 +4486,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
       "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+      "dev": true,
       "requires": {
         "base-x": "^3.0.8",
         "buffer": "^5.5.0"
@@ -4425,6 +4496,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.1.tgz",
       "integrity": "sha512-yrrU/K8zHyAH2B0slNVeq3AiwluflHpgQ3TAzwNJcuO2AoPyXgBT2EDkdbP1D8B/yFOY+S2hDYmFlI1vhVFkQw==",
+      "dev": true,
       "requires": {
         "buffer": "^5.5.0",
         "varint": "^5.0.0"
@@ -4434,6 +4506,7 @@
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.19.tgz",
       "integrity": "sha512-ej74GAfA20imjj00RO5h34aY3pGUFyzn9FJZFWwdeUHlHTkKmv90FrNpvYT4jYf1XXCy5O/5EjVnxTaESgOM6A==",
+      "dev": true,
       "requires": {
         "buffer": "^5.5.0",
         "multibase": "^0.7.0",
@@ -4444,6 +4517,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.1.tgz",
       "integrity": "sha512-qu3eIXHebc9a4OU4n/60BdZLFpX+/dGBs3DbzXCxX1aU0rFF19KQAiGl+sRL9wvKIJdeF2+w16RRJrpyTHpkkA==",
+      "dev": true,
       "requires": {
         "blakejs": "^1.1.0",
         "buffer": "^5.4.3",
@@ -4456,7 +4530,8 @@
     "murmurhash3js-revisited": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
-      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
+      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -4467,7 +4542,8 @@
     "nanoid": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.3.tgz",
-      "integrity": "sha512-Zw8rTOUfh6FlKgkEbHiB1buOF2zOPOQyGirABUWn+9Z7m9PpyoLVkh6Ksc53vBjndINQ2+9LfRPaHxb/u45EGg=="
+      "integrity": "sha512-Zw8rTOUfh6FlKgkEbHiB1buOF2zOPOQyGirABUWn+9Z7m9PpyoLVkh6Ksc53vBjndINQ2+9LfRPaHxb/u45EGg==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -4503,7 +4579,8 @@
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "dev": true
     },
     "node-int64": {
       "version": "0.4.0",
@@ -4746,7 +4823,8 @@
     "p-defer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+      "dev": true
     },
     "p-each-series": {
       "version": "2.1.0",
@@ -4758,6 +4836,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
       "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "dev": true,
       "requires": {
         "fast-fifo": "^1.0.0",
         "p-defer": "^3.0.0"
@@ -4805,7 +4884,8 @@
     "parse-duration": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.1.2.tgz",
-      "integrity": "sha512-0qfMZyjOUFBeEIvJ5EayfXJqaEXxQ+Oj2b7tWJM3hvEXvXsYCk05EDVI23oYnEw2NaFYUWdABEVPBvBMh8L/pA=="
+      "integrity": "sha512-0qfMZyjOUFBeEIvJ5EayfXJqaEXxQ+Oj2b7tWJM3hvEXvXsYCk05EDVI23oYnEw2NaFYUWdABEVPBvBMh8L/pA==",
+      "dev": true
     },
     "parse-json": {
       "version": "5.0.0",
@@ -5066,12 +5146,14 @@
     "protocol-buffers-schema": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
-      "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA=="
+      "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA==",
+      "dev": true
     },
     "protons": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/protons/-/protons-1.1.0.tgz",
       "integrity": "sha512-rxf3et88VGRJkXIcDK1nemQM9OpnKsRVuZW+vkJLRmytA6530hQ+k/r2DpclNJCYF+xUl2MXsvRsK+MJgcbfEg==",
+      "dev": true,
       "requires": {
         "protocol-buffers-schema": "^3.3.1",
         "safe-buffer": "^5.1.1",
@@ -5148,6 +5230,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -5366,7 +5449,8 @@
     "safe-buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -5600,6 +5684,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
       "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
+      "dev": true,
       "requires": {
         "varint": "~5.0.0"
       }
@@ -5889,7 +5974,8 @@
     "stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+      "dev": true
     },
     "stack-utils": {
       "version": "1.0.2",
@@ -5957,6 +6043,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.0.tgz",
       "integrity": "sha512-bK/N8LPMc4FgNxXwIRBbJDWg2GYUfnVGH++hTM5SjCHzyPPWYp2ml+wnqaO86+y0SywZDxPAZSNAPP3Wii/QzQ==",
+      "dev": true,
       "requires": {
         "get-iterator": "^1.0.2",
         "p-defer": "^3.0.0"
@@ -6040,6 +6127,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -6349,7 +6437,8 @@
     "universalify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -6415,7 +6504,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "uuid": {
       "version": "3.4.0",
@@ -6461,7 +6551,8 @@
     "varint": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
-      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
+      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8=",
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",
@@ -6549,11 +6640,6 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
-    },
-    "window-or-global": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/window-or-global/-/window-or-global-1.0.1.tgz",
-      "integrity": "sha1-2+RboqKRqrxW1iz2bEW3+jIpRt4="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   },
   "homepage": "https://github.com/ipfs-shipyard/ipfs-provider#readme",
   "dependencies": {
-    "ipfs-http-client": "^44.0.0",
     "merge-options": "^2.0.0",
     "window-or-global": "^1.0.1"
   },
   "devDependencies": {
+    "ipfs-http-client": "^44.0.0",
     "jest": "^25.4.0",
     "standard": "^14.3.3"
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Connect to IPFS via an available provider",
   "main": "src/index.js",
   "scripts": {
-    "lint": "standard ./src ./examples",
+    "lint": "standard ./src/**.js ./test/**.js ./examples/**.js",
+    "lint:fix": "standard --fix ./src/**.js ./test/**.js ./examples/**.js",
     "test": "jest --verbose ./test"
   },
   "repository": {
@@ -22,8 +23,8 @@
   },
   "homepage": "https://github.com/ipfs-shipyard/ipfs-provider#readme",
   "dependencies": {
-    "merge-options": "^2.0.0",
-    "window-or-global": "^1.0.1"
+    "iso-url": "~0.4.7",
+    "merge-options": "^2.0.0"
   },
   "devDependencies": {
     "ipfs-http-client": "^44.0.0",

--- a/src/constants/defaults.js
+++ b/src/constants/defaults.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = {
+  DEFAULT_HTTP_API: '/ip4/127.0.0.1/tcp/5001'
+}

--- a/src/constants/root.js
+++ b/src/constants/root.js
@@ -1,0 +1,8 @@
+'use strict'
+/* global self */
+
+// Establish the root object, `window` in the browser, `self` in Service Worker. or `global` on the server.
+// Credit: https://github.com/megawac/underscore/commit/365311c9a440438531ca1c6bfd49e3c7c5f46079
+module.exports = (typeof self === 'object' && self.self === self && self) ||
+  (typeof global === 'object' && global.global === global && global) ||
+  this

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,7 @@
 'use strict'
 
-const root = require('window-or-global')
-const httpClient = require('ipfs-http-client')
+const root = require('./constants/root')
 const mergeOptions = require('merge-options')
-
 const tryWebExt = require('./providers/webext')
 const tryWindow = require('./providers/window-ipfs')
 const tryHttpClient = require('./providers/http-client')
@@ -27,11 +25,7 @@ const makeProvider = (fn, defaults = {}) => {
 
 const providers = {
   httpClient: makeProvider((options) => {
-    const { location } = root
-    return tryHttpClient({ httpClient, location, ...options })
-  }, {
-    defaultApiAddress: '/ip4/127.0.0.1/tcp/5001',
-    apiAddress: null
+    return tryHttpClient({ root, ...options })
   }),
   windowIpfs: makeProvider(options => {
     return tryWindow({ root, ...options })

--- a/src/index.js
+++ b/src/index.js
@@ -48,8 +48,9 @@ async function getIpfs ({ providers = defaultProviders, ...options } = {}) {
     try {
       const res = await provider(options)
       if (res) return res
-    } catch (_) {
-      // provider failed, move to the next one
+    } catch (err) {
+      // provider failed unexpectedly, log error and move to the next one
+      console.error('[ipfs-provider]', err)
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,9 +8,12 @@ const tryHttpClient = require('./providers/http-client')
 const tryJsIpfs = require('./providers/js-ipfs')
 
 const defaultGlobalOpts = {
-  connectionTest: (ipfs) => {
-    // ipfs connection is working if can we fetch the empty directtory.
-    return ipfs.get('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')
+  connectionTest: async (ipfs) => {
+    // ipfs connection is working if we can fetch data via async iterator API
+    const cid = 'QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn'
+    for await (const file of ipfs.get(cid)) {
+      return file.type === 'dir' && file.name === cid
+    }
   }
 }
 

--- a/src/providers/http-client.js
+++ b/src/providers/http-client.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { URL } = require('iso-url')
 const PROVIDERS = require('../constants/providers')
 const { DEFAULT_HTTP_API } = require('../constants/defaults')
 
@@ -21,7 +22,7 @@ async function tryHttpClient ({ loadHttpClientModule, apiAddress, root, connecti
   let httpClient
   if (loadHttpClientModule) httpClient = await loadHttpClientModule()
 
-  // Final fllback to window.IpfsHttpClient or error
+  // Final fallback to window.IpfsHttpClient or error
   if (!httpClient) {
     if (root.IpfsHttpClient) {
       httpClient = root.IpfsHttpClient

--- a/src/providers/http-client.js
+++ b/src/providers/http-client.js
@@ -8,7 +8,7 @@ const { DEFAULT_HTTP_API } = require('../constants/defaults')
  * so it is not included as a dependency if not used.
  *
  * HTTP Client init fallback:
- * 1. Use constructor returned by getConstructor function
+ * 1. Use constructor returned by loadHttpClientModule function
  * 2. Fallback to window.IpfsHttpClient
  *
  * API URL fallback order:
@@ -16,21 +16,21 @@ const { DEFAULT_HTTP_API } = require('../constants/defaults')
  * 2. Try current origin
  * 3. Try DEFAULT_HTTP_API
 */
-async function tryHttpClient ({ getConstructor, apiAddress, root, connectionTest }) {
+async function tryHttpClient ({ loadHttpClientModule, apiAddress, root, connectionTest }) {
   // Find HTTP client
   let httpClient
-  if (getConstructor) httpClient = await getConstructor()
+  if (loadHttpClientModule) httpClient = await loadHttpClientModule()
 
   // Final fllback to window.IpfsHttpClient or error
   if (!httpClient) {
     if (root.IpfsHttpClient) {
       httpClient = root.IpfsHttpClient
     } else {
-      throw new Error('ipfs-provider could not initialize js-ipfs-http-client: make sure its constructor is returned by getConstructor function or exposed at window.IpfsHttpClient')
+      throw new Error('ipfs-provider could not initialize js-ipfs-http-client: make sure its constructor is returned by loadHttpClientModule function or exposed at window.IpfsHttpClient')
     }
   }
 
-  // Allow the use of `import` or `require` on `getConstructor` fn
+  // Allow the use of `import` or `require` on `loadHttpClientModule` fn
   httpClient = httpClient.default || httpClient // TODO: create 'import' demo in examples/
 
   // Explicit custom apiAddress provided. Only try that.
@@ -64,6 +64,7 @@ async function maybeApi ({ apiAddress, connectionTest, httpClient }) {
     return { ipfs, provider: PROVIDERS.httpClient, apiAddress }
   } catch (error) {
     // Failed to connect to ipfs-api in `apiAddress`
+    // console.error('[ipfs-provider:httpClient]', error)
     return null
   }
 }

--- a/src/providers/http-client.js
+++ b/src/providers/http-client.js
@@ -1,17 +1,45 @@
 'use strict'
 
 const PROVIDERS = require('../constants/providers')
+const { DEFAULT_HTTP_API } = require('../constants/defaults')
 
-// 1. Try user specified API address
-// 2. Try current origin
-// 3. Try multiaddr from defaultApiAddress
-async function tryHttpClient ({ httpClient, apiAddress, defaultApiAddress, location, connectionTest }) {
+/*
+ * This provider lazy-loads https://github.com/ipfs/js-ipfs-http-client
+ * so it is not included as a dependency if not used.
+ *
+ * HTTP Client init fallback:
+ * 1. Use constructor returned by getConstructor function
+ * 2. Fallback to window.IpfsHttpClient
+ *
+ * API URL fallback order:
+ * 1. Try user specified API address
+ * 2. Try current origin
+ * 3. Try DEFAULT_HTTP_API
+*/
+async function tryHttpClient ({ getConstructor, apiAddress, root, connectionTest }) {
+  // Find HTTP client
+  let httpClient
+  if (getConstructor) httpClient = await getConstructor()
+
+  // Final fllback to window.IpfsHttpClient or error
+  if (!httpClient) {
+    if (root.IpfsHttpClient) {
+      httpClient = root.IpfsHttpClient
+    } else {
+      throw new Error('ipfs-provider could not initialize js-ipfs-http-client: make sure its constructor is returned by getConstructor function or exposed at window.IpfsHttpClient')
+    }
+  }
+
+  // Allow the use of `import` or `require` on `getConstructor` fn
+  httpClient = httpClient.default || httpClient // TODO: create 'import' demo in examples/
+
   // Explicit custom apiAddress provided. Only try that.
   if (apiAddress) {
     return maybeApi({ apiAddress, connectionTest, httpClient })
   }
 
   // Current origin is not localhost:5001 so try with current origin info
+  const { location } = root
   if (location && !(location.port === '5001' && location.hostname.match(/^127.0.0.1$|^localhost$/))) {
     const origin = new URL(location.origin)
     origin.pathname = '/'
@@ -24,10 +52,11 @@ async function tryHttpClient ({ httpClient, apiAddress, defaultApiAddress, locat
   }
 
   // ...otherwise try /ip4/127.0.0.1/tcp/5001
-  return maybeApi({ apiAddress: defaultApiAddress, connectionTest, httpClient })
+  return maybeApi({ apiAddress: DEFAULT_HTTP_API, connectionTest, httpClient })
 }
 
-// Helper to construct and test an api client. Returns an js-ipfs-api instance or null
+// Init and test an api client against provded API address.
+// Returns js-ipfs-http-client instance or null
 async function maybeApi ({ apiAddress, connectionTest, httpClient }) {
   try {
     const ipfs = httpClient(apiAddress)
@@ -35,6 +64,7 @@ async function maybeApi ({ apiAddress, connectionTest, httpClient }) {
     return { ipfs, provider: PROVIDERS.httpClient, apiAddress }
   } catch (error) {
     // Failed to connect to ipfs-api in `apiAddress`
+    return null
   }
 }
 

--- a/src/providers/js-ipfs.js
+++ b/src/providers/js-ipfs.js
@@ -12,8 +12,8 @@ function promiseMeJsIpfs (Ipfs, opts) {
   })
 }
 
-async function tryJsIpfs ({ connectionTest, getConstructor, options, init = promiseMeJsIpfs }) {
-  const Ipfs = await getConstructor()
+async function tryJsIpfs ({ connectionTest, loadJsIpfsModule, options, init = promiseMeJsIpfs }) {
+  const Ipfs = await loadJsIpfsModule()
   const ipfs = await init(Ipfs, options)
   await connectionTest(ipfs)
   return { ipfs, provider: PROVIDERS.jsIpfs }

--- a/src/providers/js-ipfs.js
+++ b/src/providers/js-ipfs.js
@@ -2,19 +2,15 @@
 
 const PROVIDERS = require('../constants/providers')
 
-function promiseMeJsIpfs (Ipfs, opts) {
+function createIpfs (ipfsModule, opts) {
   // Allow the use of `import` or `require` on `getJsIpfs` fn
-  Ipfs = Ipfs.default || Ipfs
-  return new Promise((resolve, reject) => {
-    const ipfs = new Ipfs(opts)
-    ipfs.once('ready', () => resolve(ipfs))
-    ipfs.once('error', err => reject(err))
-  })
+  ipfsModule = ipfsModule.default || ipfsModule
+  return ipfsModule.create(opts)
 }
 
-async function tryJsIpfs ({ connectionTest, loadJsIpfsModule, options, init = promiseMeJsIpfs }) {
-  const Ipfs = await loadJsIpfsModule()
-  const ipfs = await init(Ipfs, options)
+async function tryJsIpfs ({ connectionTest, loadJsIpfsModule, options, init = createIpfs }) {
+  const ipfsModule = await loadJsIpfsModule()
+  const ipfs = await init(ipfsModule, options)
   await connectionTest(ipfs)
   return { ipfs, provider: PROVIDERS.jsIpfs }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -18,7 +18,7 @@ describe('getIpfs via availabe providers', () => {
     const res = await getIpfs({
       providers: [
         providers.jsIpfs({
-          getConstructor: () => { throw new Error('provider init failed') }
+          loadJsIpfsModule: () => { throw new Error('provider init failed') }
         })
       ]
     })
@@ -73,7 +73,7 @@ describe('getIpfs via availabe providers', () => {
     const { ipfs, provider } = await getIpfs({
       providers: [
         providers.jsIpfs({
-          getConstructor: jest.fn()
+          loadJsIpfsModule: jest.fn()
         })
       ]
     })

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -2,6 +2,7 @@
 /* global jest, describe, it, expect */
 
 const httpClient = require('ipfs-http-client')
+const { URL } = require('iso-url')
 
 const tryWebExt = require('../src/providers/webext.js')
 const tryWindow = require('../src/providers/window-ipfs.js')
@@ -214,7 +215,7 @@ describe('provider: httpClient', () => {
     const config = ipfs.getEndpointConfig()
     expect(config.host).toEqual('1.2.3.4')
     expect(config.port).toEqual('1111')
-    expect(config.protocol).toEqual('https')
+    expect(config.protocol).toEqual('https:')
   })
 
   it('should prefer loadHttpClientModule over window.IpfsHttpClient', async () => {

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -92,7 +92,7 @@ describe('provider: httpClient', () => {
       root: {
         location: new URL('http://localhost:5001')
       },
-      getConstructor: () => httpClient,
+      loadHttpClientModule: () => httpClient,
       connectionTest: jest.fn().mockResolvedValueOnce(true)
     }
     const { ipfs, provider, apiAddress } = await tryHttpClient(opts)
@@ -111,7 +111,7 @@ describe('provider: httpClient', () => {
       root: {
         location: new URL('http://localhost:5001')
       },
-      getConstructor: () => httpClient,
+      loadHttpClientModule: () => httpClient,
       connectionTest: jest.fn().mockResolvedValueOnce(true)
     }
     const { ipfs, provider, apiAddress } = await tryHttpClient(opts)
@@ -129,7 +129,7 @@ describe('provider: httpClient', () => {
       root: {
         location: new URL('http://dev.local:5001/subdir/some-page.html')
       },
-      getConstructor: () => httpClient,
+      loadHttpClientModule: () => httpClient,
       connectionTest: jest.fn().mockResolvedValueOnce(true)
     }
     const { ipfs, provider, apiAddress } = await tryHttpClient(opts)
@@ -147,7 +147,7 @@ describe('provider: httpClient', () => {
       root: {
         location: new URL('https://dev.local:5001/subdir/some-page.html')
       },
-      getConstructor: () => httpClient,
+      loadHttpClientModule: () => httpClient,
       connectionTest: jest.fn().mockResolvedValueOnce(true)
     }
     const { ipfs, provider, apiAddress } = await tryHttpClient(opts)
@@ -166,7 +166,7 @@ describe('provider: httpClient', () => {
       root: {
         location: new URL('http://localhost:9999/subdir/some-page.html')
       },
-      getConstructor: () => fakeHttpClient,
+      loadHttpClientModule: () => fakeHttpClient,
       connectionTest: jest.fn().mockResolvedValueOnce(true)
     }
     const { provider, apiAddress } = await tryHttpClient(opts)
@@ -181,7 +181,7 @@ describe('provider: httpClient', () => {
       root: {
         location: new URL('http://astro.cat:5001')
       },
-      getConstructor: () => httpClient,
+      loadHttpClientModule: () => httpClient,
       // location call fails, default ok
       connectionTest: jest.fn()
         .mockRejectedValueOnce(new Error('nope'))
@@ -197,14 +197,14 @@ describe('provider: httpClient', () => {
     expect(config.protocol).toEqual('http:')
   })
 
-  it('should use window.IpfsHttpClient if present and no getConstructor is provided', async () => {
+  it('should use window.IpfsHttpClient if present and no loadHttpClientModule is provided', async () => {
     const opts = {
       apiAddress: '/ip4/1.2.3.4/tcp/1111/https',
       root: {
         IpfsHttpClient: httpClient,
         location: new URL('http://example.com')
       },
-      getConstructor: undefined, // (missing on purpose)
+      loadHttpClientModule: undefined, // (missing on purpose)
       connectionTest: jest.fn().mockResolvedValueOnce(true)
     }
     const { ipfs, provider, apiAddress } = await tryHttpClient(opts)
@@ -217,7 +217,7 @@ describe('provider: httpClient', () => {
     expect(config.protocol).toEqual('https')
   })
 
-  it('should prefer getConstructor over window.IpfsHttpClient', async () => {
+  it('should prefer loadHttpClientModule over window.IpfsHttpClient', async () => {
     const constructorHttpClient = jest.fn()
     const windowHttpClient = jest.fn()
     const opts = {
@@ -226,7 +226,7 @@ describe('provider: httpClient', () => {
         IpfsHttpClient: windowHttpClient,
         location: new URL('http://example.com')
       },
-      getConstructor: () => constructorHttpClient,
+      loadHttpClientModule: () => constructorHttpClient,
       connectionTest: jest.fn().mockResolvedValueOnce(true)
     }
     const { apiAddress } = await tryHttpClient(opts)
@@ -235,17 +235,17 @@ describe('provider: httpClient', () => {
     expect(constructorHttpClient.mock.calls.length).toBe(1)
   })
 
-  it('should throw is no getConstructor nor window.IpfsHttpClient is provided', async () => {
+  it('should throw is no loadHttpClientModule nor window.IpfsHttpClient is provided', async () => {
     const opts = {
       apiAddress: '/ip4/1.2.3.4/tcp/1111/https',
       root: {
         IpfsHttpClient: undefined,
         location: new URL('http://example.com')
       },
-      getConstructor: undefined,
+      loadHttpClientModule: undefined,
       connectionTest: jest.fn().mockResolvedValueOnce(true)
     }
-    const expectedError = new Error('ipfs-provider could not initialize js-ipfs-http-client: make sure its constructor is returned by getConstructor function or exposed at window.IpfsHttpClient')
+    const expectedError = new Error('ipfs-provider could not initialize js-ipfs-http-client: make sure its constructor is returned by loadHttpClientModule function or exposed at window.IpfsHttpClient')
     expect(tryHttpClient(opts)).rejects.toEqual(expectedError)
   })
 })
@@ -255,7 +255,7 @@ describe('provider: js-ipfs', () => {
     const mockIpfs = {}
     const opts = {
       connectionTest: jest.fn().mockResolvedValueOnce(true),
-      getConstructor: jest.fn().mockResolvedValueOnce(true),
+      loadJsIpfsModule: jest.fn().mockResolvedValueOnce(true),
       options: {},
       init: jest.fn().mockResolvedValue(mockIpfs)
     }


### PR DESCRIPTION
This PR:

- removes `js-ipfs-http-client` from the default bundle, 
  (enabling people to lazily load it only when it is actually needed)
  - Supersedes #7, Closes #6 
  - We want to ship it together with  https://github.com/ipfs-shipyard/ipfs-provider/issues/3 
- adds support for async iterator JS APIs
  https://blog.ipfs.io/2020-02-01-async-await-refactor/ 
- **updates `README` and code in `./examples`**
  - **TLDR**: see updated README at https://github.com/ipfs-shipyard/ipfs-provider/blob/feat/lazy-load-ipfs-http-client/README.md
- ensure URL implementation is correct in Node environments (`iso-url`)




First two are breaking changes, so I plan to release as v1.0.0.
We need this for unblocking some collabs, such as kiwix-js.
