### PR TITLE
refactor: make webExt a generic provider

### DIFF
--- a/src/providers/webext.js
+++ b/src/providers/webext.js
@@ -7,17 +7,17 @@ async function tryWebExt ({ root, connectionTest }) {
   if (typeof root.chrome === 'object' && root.chrome.extension && root.chrome.extension.getBackgroundPage) {
     // Note: under some vendors getBackgroundPage() will return null if window is in incognito mode
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1329304
-    let webExt = null
+    let bg = null
     try {
-      webExt = root.chrome.extension.getBackgroundPage()
+      bg = root.chrome.extension.getBackgroundPage()
     } catch (err) {
-      // no ipfs companion for you
+      // not in browser extension
       return null
     }
-    // If extension is ipfs-companion and it is exposing IPFS API,
-    // use it directly for the best performance
-    if (webExt && webExt.ipfsCompanion && webExt.ipfsCompanion.ipfs) {
-      const ipfs = webExt.ipfsCompanion.ipfs
+    // If extension is exposing IPFS API as `ipfs` on the background page
+    // it can be used directly for the best performance
+    if (bg && bg.ipfs) {
+      const { ipfs } = bg
       await connectionTest(ipfs)
       return { ipfs, provider: PROVIDERS.webext }
     }

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -10,18 +10,17 @@ const tryJsIpfs = require('../src/providers/js-ipfs.js')
 const PROVIDERS = require('../src/constants/providers.js')
 
 describe('provider: webext', () => {
-  it('should connect to webext', async () => {
-    // chrome.extension.getBackgroundPage().ipfsCompanion.ipfs will be present
-    // only if page was loaded from a path that belongs to our browser extension
+  it('should connect to ipfs API exposed on extension background page ', async () => {
+    // chrome.extension.getBackgroundPage().ipfs will be present
+    // only if ipfs-provider code is executed on a page loaded from a path
+    // that belongs to a browser extension (assumes WebExtension Manifest v2)
     const mockIpfs = {}
     const root = {
       chrome: {
         extension: {
           getBackgroundPage () {
             return {
-              ipfsCompanion: {
-                ipfs: mockIpfs
-              }
+              ipfs: mockIpfs
             }
           }
         }


### PR DESCRIPTION
We are not using ipfs-provider in IPFS Companion at the moment.
It is a good time to update `webExt` provider and make it look for `ipfs`, so it can be used in other extensions, not only in Companion.